### PR TITLE
Fixes for updating profile data, statistics, and dashboard button behavior

### DIFF
--- a/tandem/front-end/src/hooks/widgets/useWidgetLevels.ts
+++ b/tandem/front-end/src/hooks/widgets/useWidgetLevels.ts
@@ -84,6 +84,7 @@ export const useLevelStats = (
     onSuccess: () => {
       if (userId) {
         queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+        queryClient.invalidateQueries({ queryKey: ['global-stats'] });
       }
     },
     onError: (err: Error) => {
@@ -122,10 +123,14 @@ export const useUpdateLastLevel = (
 };
 
 export const useUpdateStreak = () => {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (userId: number) => {
       if (!userId) throw new Error('No user id');
       return updateStreak(userId);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['global-stats'] });
     },
     onError: (err: Error) => {
       toast.error(err.message);

--- a/tandem/front-end/src/pages/DashboardPage/DashboardPage.tsx
+++ b/tandem/front-end/src/pages/DashboardPage/DashboardPage.tsx
@@ -66,16 +66,15 @@ export const DashboardPage = () => {
 
   return (
     <div className={styles.container}>
-      {/* Welcome Section */}
       <section className={styles.welcomeSection}>
-        <h1 className={styles.welcomeTitle}>{t('welcome.title', { name: user?.name || t('welcome.player') })}</h1>
+        <h1 className={styles.welcomeTitle}>
+          {t('welcome.title', { name: user?.name || t('welcome.player') })}
+        </h1>
         <p className={styles.welcomeSubtitle}>{t('welcome.subtitle')}</p>
       </section>
 
-      {/* Stats Grid */}
       {stats && (
         <div className={styles.statsGrid}>
-          {/* Streak Card - используем Card с кастомными стилями */}
           <Card
             className={clsx(cardStyles.card, styles.statCard)}
             icon={<StreakIcon className={cardStyles.iconWrapper} />}
@@ -85,7 +84,6 @@ export const DashboardPage = () => {
             <div className={styles.statSubtitle}>{t('stats.streak.subtitle')}</div>
           </Card>
 
-          {/* Last Session Card */}
           {stats.lastSession && (
             <Card
               className={clsx(cardStyles.card, styles.statCard)}
@@ -99,7 +97,6 @@ export const DashboardPage = () => {
             </Card>
           )}
 
-          {/* Best Time Card */}
           <Card
             className={clsx(cardStyles.card, styles.statCard)}
             icon={<TrophyIcon className={cardStyles.iconWrapper} />}
@@ -113,16 +110,20 @@ export const DashboardPage = () => {
         </div>
       )}
 
-      {/* Games Section */}
       {games && games.length > 0 && (
         <section className={styles.gameSection}>
           <h2 className={styles.gameTitle}>{t('games.title')}</h2>
           {games.map((game) => (
             <Card key={game.id} className={clsx(cardStyles.card, styles.gameCard)}>
               <div className={styles.gameHeader}>
-                <div className={styles.gameName}>{t(`meta.${game.id}.label`, { ns: 'widgets', defaultValue: game.name })}</div>
+                <div className={styles.gameName}>
+                  {t(`meta.${game.id}.label`, { ns: 'widgets', defaultValue: game.name })}
+                </div>
                 <div className={styles.gameLevels}>
-                  {t('games.levelsCompleted', { completed: game.levelsCompleted, total: game.totalLevels })}
+                  {t('games.levelsCompleted', {
+                    completed: game.levelsCompleted,
+                    total: game.totalLevels,
+                  })}
                 </div>
               </div>
 
@@ -146,7 +147,7 @@ export const DashboardPage = () => {
                   disabled={continueGameMutation.isPending}
                   className={buttonStyles.btn}
                 >
-                  {continueGameMutation.isPending ? t('games.loading') : t('games.continue')}
+                  {t('games.continue')}
                 </Button>
               </div>
             </Card>

--- a/tandem/front-end/src/pages/ProfilePage/ProfilePage.tsx
+++ b/tandem/front-end/src/pages/ProfilePage/ProfilePage.tsx
@@ -97,6 +97,7 @@ export const ProfilePage = () => {
       onSuccess: () => {
         setEditFields({ name: false, email: false, about: false });
         setDraft(null);
+        queryClient.invalidateQueries({ queryKey: ['global-stats'] });
       },
     });
   };
@@ -202,9 +203,7 @@ export const ProfilePage = () => {
             <SectionCard title={t('securityTitle')}>
               <div className="space-y-3">
                 <div className="p-3 rounded-xl bg-white/5 border border-[var(--color-border-light)] transition animate-pulse-hover hover:border-[var(--color-primary)]">
-                  <p className="text-[var(--color-text-muted)] text-sm mb-2">
-                    {t('passwordDesc')}
-                  </p>
+                  <p className="text-[var(--color-text-muted)] text-sm mb-2">{t('passwordDesc')}</p>
                   <div className="flex justify-start mt-4">
                     <Button
                       variant="ghost"
@@ -217,9 +216,7 @@ export const ProfilePage = () => {
                 </div>
 
                 <div className="p-3 rounded-xl bg-white/5 border border-[var(--color-border-light)] transition animate-pulse-hover hover:border-[var(--color-primary)]">
-                  <p className="text-[var(--color-text-muted)] text-sm mb-2">
-                    {t('deleteDesc')}
-                  </p>
+                  <p className="text-[var(--color-text-muted)] text-sm mb-2">{t('deleteDesc')}</p>
                   <div className="flex justify-center mt-4">
                     <Button
                       variant="ghost"


### PR DESCRIPTION
**1. Синхронизация имени пользователя на странице статистики после редактирования профиля**

Проблема:
При изменении имени в профиле данные на странице статистики не обновлялись при переходе через хедер (без жёсткой перезагрузки).
Решение: добавлен кляю инвалидации queryClient.invalidateQueries({ queryKey: ['global-stats'] });

**2. Обновление статистики уровней после прохождения виджетов**

Проблема:
Количество пройденных уровней и другие метрики в таблице глобальной статистики не обновлялись после завершения уровня в любом виджете.
Причина:
Мутации, отвечающие за сохранение прогресса (useLevelStats, useUpdateStreak), не инвалидировали кеш запроса global-stats.
Решение:
В useLevelStats добавлен вызов queryClient.invalidateQueries({ queryKey: ['global-stats'] }) в onSuccess.
В useUpdateStreak добавлен аналогичный вызов (хук перенесён на использование useQueryClient и инвалидирует кеш статистики).

**3. Устранение «скачков» кнопки Continue на дашборде**

Проблема:
При клике на кнопку «Continue» текст кнопки менялся на «Loading...», что приводило к изменению ширины кнопки и визуальному «скачку» элементов.
Решение:
Убран условный текст в DashboardPage.tsx. Кнопка теперь всегда отображает «Continue» (t('games.continue')), а во время выполнения мутации только блокируется (disabled={continueGameMutation.isPending}).
